### PR TITLE
Save() write-path hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A distraction-free terminal text editor. Black screen, a centered page, and one line at the foot that tells you where you are.
 
 [![License](https://img.shields.io/github/license/MawCeron/justwrite?style=for-the-badge)](https://github.com/MawCeron/justwrite/blob/main/LICENSE)
-![Go](https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=for-the-badge&logo=go&logoColor=white)
 ![Bubble Tea](https://img.shields.io/badge/Bubble%20Tea-FF69B4?style=for-the-badge)
 
 <img src="assets/writing.svg" alt="A page of text centred in a wider terminal, with a status bar at the foot showing the filename and an unsaved marker" width="100%">

--- a/internal/editor/file.go
+++ b/internal/editor/file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 // ErrNoPath means the document has never been named, so the caller should ask
@@ -38,12 +39,28 @@ func (e *Editor) Save() error {
 	if e.Path == "" {
 		return ErrNoPath
 	}
-	tmp := e.Path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(e.Text()), 0o644); err != nil {
+	dir := filepath.Dir(e.Path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(e.Path)+".*.tmp")
+	if err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, e.Path); err != nil {
-		os.Remove(tmp)
+	tmpPath := tmp.Name()
+	if _, err := tmp.WriteString(e.Text()); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, e.Path); err != nil {
+		os.Remove(tmpPath)
 		return err
 	}
 	e.Modified = false

--- a/internal/editor/file.go
+++ b/internal/editor/file.go
@@ -39,6 +39,11 @@ func (e *Editor) Save() error {
 	if e.Path == "" {
 		return ErrNoPath
 	}
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(e.Path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
 	dir := filepath.Dir(e.Path)
 	tmp, err := os.CreateTemp(dir, filepath.Base(e.Path)+".*.tmp")
 	if err != nil {
@@ -50,7 +55,7 @@ func (e *Editor) Save() error {
 		os.Remove(tmpPath)
 		return err
 	}
-	if err := tmp.Chmod(0o644); err != nil {
+	if err := tmp.Chmod(mode); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		return err

--- a/internal/editor/file.go
+++ b/internal/editor/file.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // ErrNoPath means the document has never been named, so the caller should ask
@@ -60,6 +61,11 @@ func (e *Editor) Save() error {
 		os.Remove(tmpPath)
 		return err
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpPath)
 		return err
@@ -68,8 +74,24 @@ func (e *Editor) Save() error {
 		os.Remove(tmpPath)
 		return err
 	}
+	syncDir(dir)
 	e.Modified = false
 	return nil
+}
+
+// syncDir best-effort fsyncs dir so the rename above survives a power loss,
+// not just a crashed process. Windows has no equivalent, so this is a no-op
+// there.
+func syncDir(dir string) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer d.Close()
+	d.Sync()
 }
 
 // SaveAs names the document and saves it. The name only sticks if the write

--- a/internal/editor/file_test.go
+++ b/internal/editor/file_test.go
@@ -3,6 +3,7 @@ package editor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -53,6 +54,34 @@ func TestSaveDoesNotClobberAPreexistingTmpFile(t *testing.T) {
 
 	if b, err := os.ReadFile(foreign); err != nil || string(b) != "no me toques" {
 		t.Errorf("the pre-existing .tmp file is %q (%v), want it untouched", b, err)
+	}
+}
+
+// A document opened at a stricter mode than 0644 — a private journal at 0600,
+// say — must not come back looser just because it went through Save().
+func TestSavePreservesFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file modes don't distinguish 0600 from 0644")
+	}
+
+	path := filepath.Join(t.TempDir(), "privado.md")
+	if err := os.WriteFile(path, []byte("secreto"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	e.SetText("secreto nuevo")
+	e.Path = path
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 0600", got)
 	}
 }
 

--- a/internal/editor/file_test.go
+++ b/internal/editor/file_test.go
@@ -24,9 +24,35 @@ func TestSaveWritesTheDocument(t *testing.T) {
 		t.Error("the document is still marked modified after a good save")
 	}
 	// The write goes through a temporary file; leaving it behind would litter
-	// the writing directory with .tmp files on every ctrl+s.
-	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
-		t.Error("the temporary file was left behind")
+	// the writing directory with stray files on every ctrl+s.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("directory has %d entries after save, want 1 (the temp file was left behind)", len(entries))
+	}
+}
+
+// Save() draws its temporary name from os.CreateTemp, so a file that happens
+// to already be named <doc>.tmp must not be mistaken for it and destroyed.
+func TestSaveDoesNotClobberAPreexistingTmpFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nota.md")
+	foreign := path + ".tmp"
+	if err := os.WriteFile(foreign, []byte("no me toques"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	e.SetText("hola")
+	e.Path = path
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if b, err := os.ReadFile(foreign); err != nil || string(b) != "no me toques" {
+		t.Errorf("the pre-existing .tmp file is %q (%v), want it untouched", b, err)
 	}
 }
 
@@ -51,6 +77,11 @@ func TestAFailedSaveLeavesTheOriginalAlone(t *testing.T) {
 	}
 	e.Path = blocked
 
+	before, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := e.Save(); err == nil {
 		t.Fatal("saving onto a directory should fail")
 	}
@@ -60,8 +91,12 @@ func TestAFailedSaveLeavesTheOriginalAlone(t *testing.T) {
 	if b, _ := os.ReadFile(path); string(b) != "el borrador bueno" {
 		t.Errorf("the original file changed: %q", b)
 	}
-	if _, err := os.Stat(blocked + ".tmp"); !os.IsNotExist(err) {
-		t.Error("the temporary file was left behind after a failure")
+	after, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("directory has %d entries after a failed save, want %d (the temp file was left behind)", len(after), len(before))
 	}
 }
 


### PR DESCRIPTION
## What changed

Three related fixes to `Editor.Save()` (`internal/editor/file.go`), the v0.1.1 milestone: "The write path. Save() hardening: temp files, permissions, durability. Nothing visible on screen."

- `fix: use a unique temp file when saving` — `Save()` wrote through a fixed name, `<path>.tmp`, silently destroying any pre-existing file with that exact name. Now draws a unique name from `os.CreateTemp` in the same directory.
- `fix: preserve the file's permission bits on save` — the temp file was always written `0o644`, loosening a document opened at a stricter mode. Now stats the existing file and carries its mode over.
- `fix: fsync the temp file before renaming it into place` — no `fsync` before the rename meant a power loss could leave a truncated or empty document. Now writes through an explicit file handle, syncs it, and best-effort syncs the containing directory (skipped on Windows).

Closes #1, #2, #3

## Note

This branch was cut from `main`, and `develop` is currently a few commits behind `main` (missing PR #33 and PR #37). The diff below may include those in addition to the three commits above until `develop` catches up.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` and `go test -race ./...` pass
- New tests: `TestSaveDoesNotClobberAPreexistingTmpFile`, `TestSavePreservesFileMode` (skipped on Windows)