### PR TITLE
CRLF line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ opening another file, saving over an existing one — asks first.
 renamed into place, so an interrupted or failed save leaves the previous draft
 intact rather than a half-written file.
 
+**Line endings are preserved.** A file that uses CRLF keeps using CRLF;
+everything else is saved as LF. A file that mixes both is saved as CRLF.
+
 **The clipboard travels.** Copying works over SSH and inside tmux, with no
 display server. For tmux, add `set -g set-clipboard on`. Text pasted in from
 elsewhere lands as a single undo step.

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -25,6 +25,7 @@ type Editor struct {
 	buf    []rune
 	cursor int
 	anchor int
+	crlf   bool // true if the loaded file used \r\n; Save() restores it
 
 	Path     string // "" until the document has been saved somewhere
 	Modified bool
@@ -58,6 +59,7 @@ func (e *Editor) SetText(s string) {
 	e.cursor = len(e.buf)
 	e.anchor = noSel
 	e.Scroll = 0
+	e.crlf = false
 	e.undo = nil
 	e.redo = nil
 	e.pendingAt = noSel

--- a/internal/editor/file.go
+++ b/internal/editor/file.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // ErrNoPath means the document has never been named, so the caller should ask
@@ -26,11 +27,24 @@ func (e *Editor) Load(path string) error {
 	case err != nil:
 		return err
 	default:
-		e.SetText(string(b))
+		text, crlf := normalizeLineEndings(string(b))
+		e.SetText(text)
+		e.crlf = crlf
 	}
 	e.Path = path
 	e.Modified = false
 	return nil
+}
+
+// normalizeLineEndings converts CRLF (and a stray lone CR) to LF for the
+// in-memory buffer, and reports whether the file used CRLF at all. A file
+// that mixes endings is treated as CRLF — once any \r\n is present, saving
+// should not guess a third convention.
+func normalizeLineEndings(s string) (text string, crlf bool) {
+	crlf = strings.Contains(s, "\r\n")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s, crlf
 }
 
 // Save writes the document through a temporary file in the same directory and
@@ -51,7 +65,11 @@ func (e *Editor) Save() error {
 		return err
 	}
 	tmpPath := tmp.Name()
-	if _, err := tmp.WriteString(e.Text()); err != nil {
+	text := e.Text()
+	if e.crlf {
+		text = strings.ReplaceAll(text, "\n", "\r\n")
+	}
+	if _, err := tmp.WriteString(text); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		return err

--- a/internal/editor/file_test.go
+++ b/internal/editor/file_test.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -159,6 +160,130 @@ func TestLoadingAMissingFileKeepsTheName(t *testing.T) {
 	}
 	if e.Text() != "" || e.Modified {
 		t.Errorf("document is %q (modified=%v), want empty and clean", e.Text(), e.Modified)
+	}
+}
+
+// Load keeps the document's bytes as LF internally, so wrapping, the cursor
+// and the stats panel never see a \r sitting in the buffer as a stray glyph.
+func TestLoadNormalizesCRLF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "windows.md")
+	if err := os.WriteFile(path, []byte("uno\r\ndos\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	if err := e.Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := e.Text(); got != "uno\ndos\n" {
+		t.Errorf("Text() = %q, want %q", got, "uno\ndos\n")
+	}
+
+	// The stats panel counted a \r as a character on every line before this
+	// fix; with the buffer normalized there is nothing left to over-count.
+	lf := New()
+	lf.SetText("uno\ndos\n")
+	if got, want := e.CharCount(), lf.CharCount(); got != want {
+		t.Errorf("CharCount() = %d, want %d (same as the LF-only equivalent)", got, want)
+	}
+}
+
+// A file that came in as CRLF must go back out as CRLF, unmodified, or a
+// Windows collaborator sees every line flagged as changed by their VCS.
+func TestSaveRoundTripsCRLF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "windows.md")
+	original := []byte("uno\r\ndos\r\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	if err := e.Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file is %q, want it unchanged at %q", got, original)
+	}
+}
+
+// The reverse must hold too: an LF file stays LF, never picking up a \r it
+// never had.
+func TestSaveRoundTripsLF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unix.md")
+	original := []byte("uno\ndos\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	if err := e.Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file is %q, want it unchanged at %q", got, original)
+	}
+}
+
+// A document that never went through Load — started fresh with ctrl+n — has
+// no CRLF history to preserve, so it saves as LF.
+func TestNewDocumentSavesWithLF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nuevo.md")
+	e := New()
+	e.SetText("uno\ndos\n")
+	e.Path = path
+
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(got, []byte("\r")) {
+		t.Errorf("file is %q, want no CR", got)
+	}
+}
+
+// A file that mixes \r\n and bare \n has no single correct answer, so the
+// policy is: any \r\n found at all means the whole document saves as CRLF.
+func TestMixedLineEndingsPickCRLF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mixto.md")
+	if err := os.WriteFile(path, []byte("uno\r\ndos\nzz\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := New()
+	if err := e.Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "uno\r\ndos\r\nzz\r\n"; string(got) != want {
+		t.Errorf("file is %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What changed

v0.1.2 milestone: "Windows line endings. The only change in the patch series that alters the bytes written to disk."

- `fix: normalize CRLF to LF, restoring it on save` — `Load` kept bytes exactly as they came off disk, so a Windows file's `\r` sat in the buffer as an ordinary rune, corrupting wrapping/cursor placement and over-counting characters in the stats panel. Now strips `\r` on load, remembers whether the file used CRLF, and restores it on save. A mixed-ending file is saved as CRLF; a new document saves as LF.
- `docs: readme mentions line endings are preserved` — documents the policy next to the other save-behavior notes.

Closes #4

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` and `go test -race ./...` pass
- New round-trip tests: `TestLoadNormalizesCRLF`, `TestSaveRoundTripsCRLF`, `TestSaveRoundTripsLF`, `TestNewDocumentSavesWithLF`, `TestMixedLineEndingsPickCRLF`